### PR TITLE
fix: PHPStan level 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "symfony/polyfill-uuid": "^1.28"
     },
     "require-dev": {
+        "phpstan/phpstan": "^2.2",
         "rector/rector": "^2.0",
         "mikey179/vfsstream": "^1.6"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93e329737980ac44341beaa11743c756",
+    "content-hash": "1f790d87c6849bf1486d409419ba7058",
     "packages": [
         {
             "name": "bunny/bunny",
-            "version": "v0.5.4",
+            "version": "v0.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jakubkulhan/bunny.git",
-                "reference": "1f6c8f2163efaf9455c3390435424d93649f1d83"
+                "reference": "2714c26466d061e1236dbbe9b892324f8be80d63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jakubkulhan/bunny/zipball/1f6c8f2163efaf9455c3390435424d93649f1d83",
-                "reference": "1f6c8f2163efaf9455c3390435424d93649f1d83",
+                "url": "https://api.github.com/repos/jakubkulhan/bunny/zipball/2714c26466d061e1236dbbe9b892324f8be80d63",
+                "reference": "2714c26466d061e1236dbbe9b892324f8be80d63",
                 "shasum": ""
             },
             "require": {
@@ -27,6 +27,7 @@
             },
             "require-dev": {
                 "ext-pcntl": "*",
+                "phpstan/phpstan": "^1.10",
                 "phpunit/phpunit": "^9.5 || ^7.5.20",
                 "symfony/process": "^6.1 || ^4.4"
             },
@@ -66,22 +67,22 @@
             ],
             "support": {
                 "issues": "https://github.com/jakubkulhan/bunny/issues",
-                "source": "https://github.com/jakubkulhan/bunny/tree/v0.5.4"
+                "source": "https://github.com/jakubkulhan/bunny/tree/v0.5.6"
             },
-            "time": "2022-12-15T20:23:51+00:00"
+            "time": "2025-05-22T09:49:34+00:00"
         },
         {
             "name": "php-etl/bucket",
-            "version": "dev-main",
+            "version": "v0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-etl/bucket.git",
-                "reference": "233beac60eac83944160a5af993c20536d1ea1b0"
+                "reference": "11c0ac62111d7775415762dcb9c80a47801263a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-etl/bucket/zipball/233beac60eac83944160a5af993c20536d1ea1b0",
-                "reference": "233beac60eac83944160a5af993c20536d1ea1b0",
+                "url": "https://api.github.com/repos/php-etl/bucket/zipball/11c0ac62111d7775415762dcb9c80a47801263a1",
+                "reference": "11c0ac62111d7775415762dcb9c80a47801263a1",
                 "shasum": ""
             },
             "require": {
@@ -89,12 +90,11 @@
                 "php-etl/bucket-contracts": "0.3.*"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.0",
+                "friendsofphp/php-cs-fixer": "^3.38",
                 "phpspec/phpspec": "^7.3",
                 "phpstan/phpstan": "^1.10",
                 "rector/rector": "^0.15"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -123,9 +123,9 @@
             "description": "This library implements the Extract-Transform-Load pattern asynchronously in PHP with the help of iterators and generators",
             "support": {
                 "issues": "https://github.com/php-etl/bucket/issues",
-                "source": "https://github.com/php-etl/bucket/tree/main"
+                "source": "https://github.com/php-etl/bucket/tree/v0.4.1"
             },
-            "time": "2023-11-14T14:39:36+00:00"
+            "time": "2024-12-11T09:43:50+00:00"
         },
         {
             "name": "php-etl/bucket-contracts",
@@ -170,7 +170,7 @@
                     "homepage": "http://kiboko.fr"
                 },
                 {
-                    "name": "Grégory Planchat",
+                    "name": "Grégory Planchatn rules",
                     "email": "gregory@kiboko.fr"
                 }
             ],
@@ -183,16 +183,16 @@
         },
         {
             "name": "php-etl/pipeline-contracts",
-            "version": "v0.5.0",
+            "version": "v0.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-etl/pipeline-contracts.git",
-                "reference": "29aac4a1644c960355a17876e4a84bb8f0b89654"
+                "reference": "24c71241d16b7deca56d67ea0f1d591c8ae52f09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-etl/pipeline-contracts/zipball/29aac4a1644c960355a17876e4a84bb8f0b89654",
-                "reference": "29aac4a1644c960355a17876e4a84bb8f0b89654",
+                "url": "https://api.github.com/repos/php-etl/pipeline-contracts/zipball/24c71241d16b7deca56d67ea0f1d591c8ae52f09",
+                "reference": "24c71241d16b7deca56d67ea0f1d591c8ae52f09",
                 "shasum": ""
             },
             "require": {
@@ -201,7 +201,7 @@
                 "php-etl/satellite-contracts": "0.1.*"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.0",
+                "friendsofphp/php-cs-fixer": "^3.38",
                 "phpstan/phpstan": "^1.10",
                 "rector/rector": "^0.15"
             },
@@ -233,29 +233,29 @@
             "description": "This library describes contracts for the Extract-Transform-Load pattern.",
             "support": {
                 "issues": "https://github.com/php-etl/pipeline-contracts/issues",
-                "source": "https://github.com/php-etl/pipeline-contracts/tree/v0.5.0"
+                "source": "https://github.com/php-etl/pipeline-contracts/tree/v0.5.1"
             },
-            "time": "2023-11-15T10:45:24+00:00"
+            "time": "2023-11-20T10:48:56+00:00"
         },
         {
             "name": "php-etl/satellite-contracts",
-            "version": "v0.1.0",
+            "version": "v0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-etl/satellite-contracts.git",
-                "reference": "1d2bc6822bfdb3efc6a1f490e706db995c99ef41"
+                "reference": "d2be591800f42e460a59d864888aedf00f111dd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-etl/satellite-contracts/zipball/1d2bc6822bfdb3efc6a1f490e706db995c99ef41",
-                "reference": "1d2bc6822bfdb3efc6a1f490e706db995c99ef41",
+                "url": "https://api.github.com/repos/php-etl/satellite-contracts/zipball/d2be591800f42e460a59d864888aedf00f111dd7",
+                "reference": "d2be591800f42e460a59d864888aedf00f111dd7",
                 "shasum": ""
             },
             "require": {
                 "php": "^8.2"
             },
             "require-dev": {
-                "rector/rector": "^0.15.0"
+                "rector/rector": "^0.15"
             },
             "type": "library",
             "extra": {
@@ -285,39 +285,37 @@
             "description": "This library describes contracts for defining satellite formats",
             "support": {
                 "issues": "https://github.com/php-etl/satellite-contracts/issues",
-                "source": "https://github.com/php-etl/satellite-contracts/tree/v0.1.0"
+                "source": "https://github.com/php-etl/satellite-contracts/tree/v0.1.1"
             },
-            "time": "2023-04-18T13:53:22+00:00"
+            "time": "2023-11-20T10:48:56+00:00"
         },
         {
             "name": "react/event-loop",
-            "version": "v1.3.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/event-loop.git",
-                "reference": "187fb56f46d424afb6ec4ad089269c72eec2e137"
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/187fb56f46d424afb6ec4ad089269c72eec2e137",
-                "reference": "187fb56f46d424afb6ec4ad089269c72eec2e137",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
             },
             "suggest": {
-                "ext-event": "~1.0 for ExtEventLoop",
-                "ext-pcntl": "For signal handling support when using the StreamSelectLoop",
-                "ext-uv": "* for ExtUvLoop"
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "React\\EventLoop\\": "src"
+                    "React\\EventLoop\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -353,39 +351,35 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/event-loop/issues",
-                "source": "https://github.com/reactphp/event-loop/tree/v1.3.0"
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-03-17T11:10:22+00:00"
+            "time": "2025-11-17T20:46:25+00:00"
         },
         {
             "name": "react/promise",
-            "version": "v2.9.0",
+            "version": "v2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "234f8fd1023c9158e2314fa9d7d0e6a83db42910"
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/234f8fd1023c9158e2314fa9d7d0e6a83db42910",
-                "reference": "234f8fd1023c9158e2314fa9d7d0e6a83db42910",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/1a8460931ea36dc5c76838fec5734d55c88c6831",
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.36"
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
             },
             "type": "library",
             "autoload": {
@@ -429,36 +423,32 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v2.9.0"
+                "source": "https://github.com/reactphp/promise/tree/v2.11.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-02-11T10:27:51+00:00"
+            "time": "2023-11-16T16:16:50+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.28.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "9c44518a5aff8da565c8a55dbe85d2769e6f630e"
+                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/9c44518a5aff8da565c8a55dbe85d2769e6f630e",
-                "reference": "9c44518a5aff8da565c8a55dbe85d2769e6f630e",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-uuid": "*"
@@ -468,12 +458,9 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "1.28-dev"
-                },
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -507,7 +494,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.28.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -519,33 +506,38 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-26T09:26:14+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "mikey179/vfsstream",
-            "version": "v1.6.11",
+            "version": "v1.6.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bovigo/vfsStream.git",
-                "reference": "17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f"
+                "reference": "fe695ec993e0a55c3abdda10a9364eb31c6f1bf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f",
-                "reference": "17d16a85e6c26ce1f3e2fa9ceeacdc2855db1e9f",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/fe695ec993e0a55c3abdda10a9364eb31c6f1bf0",
+                "reference": "fe695ec993e0a55c3abdda10a9364eb31c6f1bf0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5|^5.0"
+                "phpunit/phpunit": "^7.5||^8.5||^9.6",
+                "yoast/phpunit-polyfills": "^2.0"
             },
             "type": "library",
             "extra": {
@@ -576,24 +568,19 @@
                 "source": "https://github.com/bovigo/vfsStream/tree/master",
                 "wiki": "https://github.com/bovigo/vfsStream/wiki"
             },
-            "time": "2022-02-23T02:02:42+00:00"
+            "time": "2024-08-29T18:43:31+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.13",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "f07bf8c6980b81bf9e49d44bd0caf2e737614a70"
-            },
+            "version": "2.1.40",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/f07bf8c6980b81bf9e49d44bd0caf2e737614a70",
-                "reference": "f07bf8c6980b81bf9e49d44bd0caf2e737614a70",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9b2c7aeb83a75d8680ea5e7c9b7fca88052b766b",
+                "reference": "9b2c7aeb83a75d8680ea5e7c9b7fca88052b766b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^7.4|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -632,31 +619,27 @@
                 {
                     "url": "https://github.com/phpstan",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2023-04-12T19:29:52+00:00"
+            "time": "2026-02-23T15:04:35+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "0.15.24",
+            "version": "2.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "716473919bcfdc27bdd2a32afb72adbf4c224e59"
+                "reference": "bbd37aedd8df749916cffa2a947cfc4714d1ba2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/716473919bcfdc27bdd2a32afb72adbf4c224e59",
-                "reference": "716473919bcfdc27bdd2a32afb72adbf4c224e59",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/bbd37aedd8df749916cffa2a947cfc4714d1ba2c",
+                "reference": "bbd37aedd8df749916cffa2a947cfc4714d1ba2c",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.10.1"
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.38"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -664,15 +647,13 @@
                 "rector/rector-phpunit": "*",
                 "rector/rector-symfony": "*"
             },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
             "bin": [
                 "bin/rector"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "0.15-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "bootstrap.php"
@@ -683,6 +664,7 @@
                 "MIT"
             ],
             "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
             "keywords": [
                 "automation",
                 "dev",
@@ -691,7 +673,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/0.15.24"
+                "source": "https://github.com/rectorphp/rector/tree/2.3.8"
             },
             "funding": [
                 {
@@ -699,17 +681,17 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-05T08:49:11+00:00"
+            "time": "2026-02-22T09:45:50+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.4"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+    level: 8
+    paths:
+        - src
+    ignoreErrors:
+        # Generator protocol: EmptyResultBucket/AcceptanceResultBucket with array|null vs array<string, mixed>
+        - '#Generator expects value type#'

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -9,6 +9,9 @@ use Bunny\Client;
 use Kiboko\Component\Bucket\AcceptanceResultBucket;
 use Kiboko\Contract\Pipeline\ExtractorInterface;
 
+/**
+ * @implements ExtractorInterface<array<string, mixed>>
+ */
 final readonly class Extractor implements ExtractorInterface
 {
     private Channel $channel;
@@ -17,7 +20,11 @@ final readonly class Extractor implements ExtractorInterface
         private Client $connection,
         private string $topic,
     ) {
-        $this->channel = $this->connection->channel();
+        $channel = $this->connection->channel();
+        if (!$channel instanceof Channel) {
+            throw new \RuntimeException('Expected Channel from Bunny client');
+        }
+        $this->channel = $channel;
 
         $this->channel->queueDeclare(
             queue: $this->topic,
@@ -70,7 +77,7 @@ final readonly class Extractor implements ExtractorInterface
     {
         while (true) {
             $message = $this->channel->get($this->topic);
-            if (null === $message) {
+            if (!$message instanceof \Bunny\Message) {
                 break;
             }
             $this->channel->ack($message);

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -10,6 +10,9 @@ use Kiboko\Component\Bucket\AcceptanceResultBucket;
 use Kiboko\Component\Bucket\EmptyResultBucket;
 use Kiboko\Contract\Pipeline\LoaderInterface;
 
+/**
+ * @implements LoaderInterface<array<string, mixed>, array<string, mixed>>
+ */
 final readonly class Loader implements LoaderInterface
 {
     private Channel $channel;
@@ -19,7 +22,11 @@ final readonly class Loader implements LoaderInterface
         private string $topic,
         private ?string $exchange = null,
     ) {
-        $this->channel = $this->connection->channel();
+        $channel = $this->connection->channel();
+        if (!$channel instanceof Channel) {
+            throw new \RuntimeException('Expected Channel from Bunny client');
+        }
+        $this->channel = $channel;
 
         $this->channel->queueDeclare(
             queue: $this->topic,
@@ -70,6 +77,7 @@ final readonly class Loader implements LoaderInterface
         return new self($connection, topic: $topic, exchange: $exchange);
     }
 
+    /** @return \Generator<int, AcceptanceResultBucket<array<string, mixed>>|EmptyResultBucket<array<string, mixed>>, array<string, mixed>|null, void> */
     public function load(): \Generator
     {
         $line = yield new EmptyResultBucket();
@@ -81,8 +89,8 @@ final readonly class Loader implements LoaderInterface
                 [
                     'content-type' => 'application/json',
                 ],
-                exchange: $this->exchange,
-                routingKey: $this->topic,
+                $this->exchange ?? '',
+                $this->topic,
             );
 
             $line = yield new AcceptanceResultBucket($line);

--- a/src/Rejection.php
+++ b/src/Rejection.php
@@ -19,7 +19,11 @@ final readonly class Rejection implements RejectionInterface
         private string $topic,
         private ?string $exchange = null,
     ) {
-        $this->channel = $this->connection->channel();
+        $channel = $this->connection->channel();
+        if (!$channel instanceof Channel) {
+            throw new \RuntimeException('Expected Channel from Bunny client');
+        }
+        $this->channel = $channel;
         $this->channel->queueDeclare(
             queue: $this->topic,
             passive: false,
@@ -88,7 +92,7 @@ final readonly class Rejection implements RejectionInterface
             [
                 'content-type' => 'application/json',
             ],
-            $this->exchange,
+            $this->exchange ?? '',
             $this->topic,
         );
     }
@@ -104,7 +108,7 @@ final readonly class Rejection implements RejectionInterface
             [
                 'content-type' => 'application/json',
             ],
-            $this->exchange,
+            $this->exchange ?? '',
             $this->topic,
         );
     }

--- a/src/State.php
+++ b/src/State.php
@@ -22,23 +22,24 @@ final class State implements StepStateInterface
     {
         $this->acceptMetric += $count;
 
-        $this->manager->trySend($this->stepCode);
+        $this->manager->trySend($count);
     }
 
     public function reject(int $count = 1): void
     {
         $this->rejectMetric += $count;
 
-        $this->manager->trySend($this->stepCode);
+        $this->manager->trySend($count);
     }
 
     public function error(int $count = 1): void
     {
         $this->errorMetric += $count;
 
-        $this->manager->trySend($this->stepCode);
+        $this->manager->trySend($count);
     }
 
+    /** @return array<string, mixed> */
     public function toArray(): array
     {
         return [

--- a/src/StateManager.php
+++ b/src/StateManager.php
@@ -9,8 +9,9 @@ use Bunny\Client;
 
 class StateManager
 {
-    /** @var list<State> */
+    /** @var array<string, State> */
     private array $steps = [];
+    /** @var list<State> */
     private array $tearedDown = [];
     private int $messageCount = 0;
     private int $lineCount = 0;
@@ -22,7 +23,11 @@ class StateManager
         private readonly int $lineThreshold = 1000,
         private readonly ?string $exchange = null,
     ) {
-        $this->channel = $this->connection->channel();
+        $channel = $this->connection->channel();
+        if (!$channel instanceof Channel) {
+            throw new \RuntimeException('Expected Channel from Bunny client');
+        }
+        $this->channel = $channel;
 
         $this->channel->queueDeclare(
             queue: $this->topic,
@@ -43,7 +48,7 @@ class StateManager
         return $this->steps[$stepCode] = new State($this, $stepCode, $stepLabel);
     }
 
-    public function trySend($count): void
+    public function trySend(int $count): void
     {
         $this->lineCount += $count;
 
@@ -80,7 +85,7 @@ class StateManager
             [
                 'content-type' => 'application/json',
             ],
-            $this->exchange,
+            $this->exchange ?? '',
             $this->topic
         );
     }


### PR DESCRIPTION
## Summary

Corrections pour la compatibilité PHPStan niveau 8.

## Changes

- Ajout phpstan/phpstan ^2.2 en require-dev
- Vérification `instanceof Channel` pour API Bunny (sync/async)
- Types State, StateManager, Loader
- trySend(int $count), correction State::accept/reject/error
- phpstan.neon niveau 8 avec ignore pour protocole Generator